### PR TITLE
Updated  onMonthChange() to return current month

### DIFF
--- a/components/ScrollMonthCalender/index.js
+++ b/components/ScrollMonthCalender/index.js
@@ -24,7 +24,7 @@ function ScrollMonthCalender({history, enableDefaultStyles , onMonthChange}){
         if(monthNumber>11)
           setMonthNumber(11)
         scrollViewRef.current.getNode().scrollTo({x:heightArray[monthNumber]-100, y:0})
-        onMonthChange()
+        onMonthChange(history[monthNumber].month)
     },[monthNumber])
 
     return (


### PR DESCRIPTION
onMonthChange() lets us know when the user has changed the month but doesn't return the current month it's on. 

I simply updated the props to return the current month.